### PR TITLE
Disable entropy cache for UUID creation

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,8 +45,8 @@ async function getSize(c, id) {
 }
 
 async function registerRequest(c) {
-  const server = crypto.randomUUID()
-  const client = crypto.randomUUID()
+  const server = crypto.randomUUID({disableEntropyCache: true})
+  const client = crypto.randomUUID({disableEntropyCache: true})
 
   await Promise.all([
     putToken(c, server),


### PR DESCRIPTION
According to [the docs for crypto.randomUUID](https://nodejs.org/api/crypto.html#cryptorandomuuidoptions), it allocates enough memory to create 128 UUIDs when you call the function. This is a performance enhancement for long-running Node processes, but is actually exclusively harmful for our short-lived worker environments.

This could actually hurt performance on self-hosted Express Services, but I feel like the impact of losing the cache would be bigger for Workers than for Self Hosted (given that Workers pricing includes memory - though I don't think we're anywhere close to the minimum increment for gb/s or whatever anyway 😒)

I would've also done this for the UUID creation on the data itself, but I skipped it in case there's some nasty side-effect of this I'm not realizing. If this change works well for awhile we can try it out.